### PR TITLE
管理者セッションチェックAPIの改修＆修正

### DIFF
--- a/api/src/controllers/admin/session.controller.ts
+++ b/api/src/controllers/admin/session.controller.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from "express";
 import { Cookies, requestHeaders, ResponseStatus } from "@config/constants";
-import { SuccessStatus, ErrorStatus, AdminSessionInfo, AdminStatus } from "@types";
-import { createSession, deleteSession, getSession, verifySessionOld } from "@services/redis/sessionService";
-import { idPasswordVerify, createAdmin } from "@services/postgres/admins.service";
+import { SuccessStatus, ErrorStatus, AdminStatus } from "@types";
+import { createSession, deleteSession, getSession, verifySession, verifySessionOld } from "@services/redis/sessionService";
+import { idPasswordVerify } from "@services/postgres/admins.service";
 import { AdminSessionInput } from "@schemas/adminSession.schema";
 import { createCsrf, deleteCsrf, verifyCsrf } from "@services/redis/csrfService";
 import { buildSuccessResponse } from "@lib/response/buildResponse";
@@ -10,15 +10,21 @@ import { deleteAdminSidCookie, deleteAdminStatusCookie, setAdminSidCookie, setAd
 import { BadRequestError, CsrfIssuanceFailedError, ForbiddenError, InternalServerError, LnAdminSidIssuanceFailedError, MaxRequestError, UnauthorizedError } from "@errors";
 
 /**
- * API仕様
+ * 管理者ログインチェックAPI
  * Cookieのln_admin_sidを検証し、セッションの有効性を返す。
  * 原則としてSet-Cookieを返さない
+ * 
+ * ▼ 処理概要
  *
- * 流れとしては、ln_admin_sidからRedis内に一致するln_admin_sidを検索
- * 一致するもので有効なものがあれば、セッションを有効として返す。
+ * 1. cookies から sid, adminStatusを取得する
+ * ※取得できない場合は UnauthorizedError 
+ * 2. verifySession関数でセッションの有効性をチェックし有効な場合は次の処理へ
+ * ※無効なセッションの場合は UnauthorizedError
+ * 3. getSession関数でセッションの内容を取得し、resData を生成して Response を生成
  */
 export const getAdminSession = async (req: Request, res: Response) => {
-  // 2) Cookieから ln_admin_sid / admin_status を取り出す / 取得できない場合は401エラーを返す
+  // 1. cookies から sid, adminStatusを取得する
+  // ※取得できない場合は UnauthorizedError 
   const sid: string = req.cookies?.[Cookies.COOKIE_NAME_ADMIN_SESSION];
   const adminStatus: AdminStatus = req.cookies?.[Cookies.COOKIE_NAME_ADMIN_STATUS];
 
@@ -26,16 +32,23 @@ export const getAdminSession = async (req: Request, res: Response) => {
     throw new UnauthorizedError();
   }
 
-  // 3) sidをkeyとしてKVSを検索: 有効なセッションがある場合は200 / そうでない場合は401を返す
-  const data: { verifyResult: boolean; resData?: AdminSessionInfo } | undefined = await verifySessionOld(sid, adminStatus);
-  console.log(data);
-  if (!data?.["verifyResult"] || !data.resData) { // redisからデータが取得できない場合 または data.verifyResultがfalseの場合
-    throw new UnauthorizedError();
-  }
+  // 2. verifySession関数でセッションの有効性をチェックし有効な場合は次の処理へ
+  // ※無効なセッションの場合は UnauthorizedError
+  const verifySessionResult: boolean = await verifySession(sid, adminStatus);
+  if (!verifySessionResult) return new UnauthorizedError();
 
-  console.log(data.resData);
-  // TODO messageを後々整理（型として扱う）するかも
-  return buildSuccessResponse(req, res, ResponseStatus.OK, data.resData, {}, "有効なセッションです");
+  // 3. getSession関数でセッションの内容を取得し、resData を生成して Response を生成
+  const session = await getSession(sid, adminStatus);
+  if (!session || !session.adminId || !session.email || !session.displayName) {
+    return new UnauthorizedError();
+  }
+  const resData = {
+    adminStatus: adminStatus,
+    id: session.adminId,
+    email: session.email,
+    displayName: session.displayName
+  }
+  return buildSuccessResponse(req, res, ResponseStatus.OK, resData, {}, "有効なセッションです");
 };
 
 /**

--- a/api/src/controllers/admin/session.controller.ts
+++ b/api/src/controllers/admin/session.controller.ts
@@ -24,29 +24,44 @@ import { BadRequestError, CsrfIssuanceFailedError, ForbiddenError, InternalServe
  */
 export const getAdminSession = async (req: Request, res: Response) => {
   // 1. cookies から sid, adminStatusを取得する
-  // ※取得できない場合は UnauthorizedError 
-  const sid: string = req.cookies?.[Cookies.COOKIE_NAME_ADMIN_SESSION];
-  const adminStatus: AdminStatus = req.cookies?.[Cookies.COOKIE_NAME_ADMIN_STATUS];
-
-  if (!sid || !adminStatus) {
+  // 生データの確認（sid, adminStatus）
+  const cookieSid = req.cookies?.[Cookies.COOKIE_NAME_ADMIN_SESSION];
+  const cookieAdminStatus = req.cookies?.[Cookies.COOKIE_NAME_ADMIN_STATUS];
+  if (
+    !cookieSid ||
+    !cookieAdminStatus ||
+    cookieAdminStatus.trim() === ''
+  ) {
     throw new UnauthorizedError();
-  }
+  };
+
+  // ※取得できない場合は UnauthorizedError 
+  const sid: string = cookieSid;
+  const adminStatus: AdminStatus = Number(cookieAdminStatus) as AdminStatus;
+
+  // adminStatus の NaNチェック
+  if (Number.isNaN(adminStatus)) throw new UnauthorizedError();
 
   // 2. verifySession関数でセッションの有効性をチェックし有効な場合は次の処理へ
   // ※無効なセッションの場合は UnauthorizedError
   const verifySessionResult: boolean = await verifySession(sid, adminStatus);
-  if (!verifySessionResult) return new UnauthorizedError();
+  if (!verifySessionResult) throw new UnauthorizedError();
 
   // 3. getSession関数でセッションの内容を取得し、resData を生成して Response を生成
   const session = await getSession(sid, adminStatus);
-  if (!session || !session.adminId || !session.email || !session.displayName) {
-    return new UnauthorizedError();
+  if (!session || !session.adminId || !session.email || !session.displayName || !session.expiredAt) {
+    throw new UnauthorizedError();
   }
+
   const resData = {
-    adminStatus: adminStatus,
-    id: session.adminId,
-    email: session.email,
-    displayName: session.displayName
+    valid: true,
+    expiresAt: session.expiredAt,
+    admin: {
+      adminStatus: adminStatus,
+      id: Number(session.adminId),
+      email: session.email,
+      displayName: session.displayName
+    }
   }
   return buildSuccessResponse(req, res, ResponseStatus.OK, resData, {}, "有効なセッションです");
 };

--- a/api/src/services/redis/sessionService.ts
+++ b/api/src/services/redis/sessionService.ts
@@ -140,7 +140,7 @@ export const createSession = async (req: Request, adminId: number, adminStatus: 
 }
 
 /**
- * セッション検証韓嵩
+ * セッション検証関数
  * 
  * ▼ 処理概要
  * 1. sid, statusId を受け取り, RedisKey(sidKey) を生成する

--- a/api/src/services/redis/sessionService.ts
+++ b/api/src/services/redis/sessionService.ts
@@ -283,14 +283,12 @@ export const getSession = async (sid: string, adminStatus: AdminStatus): Promise
     : adminSessionKey(sid);
 
   const redisRaw: string | null = await redis.get(sidKey);
-
   if (!redisRaw) {
     return false;
   }
 
   // sidKey 内に取得されている型は RedisAdminSession | RedisAdminTmpSession なので強制的に型変更
   const adminSession = JSON.parse(redisRaw) as unknown as RedisAdminSession | RedisAdminTmpSession;
-  
   // expiredAt を UTC ISO 8601 形式に変換する
   adminSession.expiredAt = (new Date(Number(adminSession.expiredAt))).toISOString();
   return adminSession;

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -38,7 +38,7 @@ paths:
         ※component の関係でその他の500error の例が載っています。
       security:
         - Cookie_ln_admin_sid: []
-        - Cookie_admin_status: []
+          Cookie_admin_status: []
       responses:
         '200':
           description: 有効なセッション
@@ -60,6 +60,7 @@ paths:
                       valid: true
                       expiresAt: "2025-08-18T06:00:00Z"
                       admin:
+                        adminStatus: 3
                         id: 2
                         email: "linknest@example.com"
                         displayName: "テスト管理者"
@@ -76,6 +77,7 @@ paths:
                       valid: true
                       expiresAt: "2025-08-18T06:00:00Z"
                       admin:
+                        adminStatus: 1
                         id: 3
                         email: "first-login@example.com"
                         displayName: "初回ログインテスト管理者"
@@ -209,6 +211,7 @@ paths:
           $ref: '#/components/responses/CsrfForbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
   /api/admin/session/refresh:
     post:
       tags:
@@ -257,6 +260,7 @@ paths:
           $ref: '#/components/responses/CsrfForbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
   /api/admin/admins:
     post:
       tags:
@@ -270,7 +274,7 @@ paths:
         required: true
         content:
           application/json:
-            schema: 
+            schema:
               $ref: '#/components/schemas/RegisterRequest'
       responses:
         '201':
@@ -299,6 +303,7 @@ paths:
           $ref: '#/components/responses/ConflictAdmin'
         '500':
           $ref: '#/components/responses/InternalServerErrorServerErrorOnly'
+
   /api/admin/admins/otp:
     post:
       tags:
@@ -332,7 +337,7 @@ paths:
                     message: "OTP送信完了"
                     data:
                       nextPath: "/login/first/otp/verify"
-                      otpDeliveryAddress:  "linknest@otp-delivery.com"
+                      otpDeliveryAddress: "linknest@otp-delivery.com"
                       expiresAt: "2025-12-14T12:55:00.000Z"
                     meta:
                       csrfToken: "csrf_token"
@@ -359,7 +364,7 @@ paths:
         - ln_admin_sid, admin_status が未送信 / 検証失敗 : 401 / UNAUTHORIZED
         - x-csrf-token が未送信 : 400 / CSRF_MISSING_HEADER
         - x-csrf-token の検証に失敗 : 403 / CSRF_FORBIDDEN
-        
+
         ■OTP検証の結果による処理
         - otp の検証に失敗 : 401 / OTP_UNAUTHORIZED
         - otp の検証に失敗（5回以上） : 423 / MAX_REQUEST
@@ -374,7 +379,7 @@ paths:
         required: true
         content:
           application/json:
-            schema: 
+            schema:
               $ref: '#/components/schemas/VerifyOtp'
       responses:
         '200':
@@ -535,7 +540,7 @@ components:
           example: '2025-08-19T07:33:00Z'
           description: セッション失効予定時刻（返却は任意）
         admin:
-          $ref: '#/components/schemas/AdminPublic' # (返却は任意)
+          $ref: '#/components/schemas/AdminSessionPublic' # (返却は任意)
 
     LoginSuccessData:
       type: object
@@ -606,6 +611,26 @@ components:
           format: date-time
           example: '2025-08-19T10:00:00Z'
 
+    # ===== 追加: セッション取得専用の管理者公開情報（adminStatusあり） =====
+    AdminSessionPublic:
+      type: object
+      required: [adminStatus, id, email, displayName]
+      properties:
+        adminStatus:
+          type: integer
+          example: 3
+          description: 管理者ステータス（例：1=pre-otp, 3=本登録 など）
+        id:
+          type: integer
+          example: 1
+        email:
+          type: string
+          format: email
+          example: linknest@example.com
+        displayName:
+          type: string
+          example: 管理者太郎
+
     AdminPublic:
       type: object
       properties:
@@ -636,6 +661,7 @@ components:
           type: string
           format: password
           example: Asdf12345!
+
     RegisterRequest:
       type: object
       required: [email, password]
@@ -673,7 +699,7 @@ components:
             OTPは数字6桁
           pattern: '^\d{6}$'
           example: "123456"
-          
+
     # ===== 各エンドポイントのレスポンス（envelope付き） =====
     SessionStatusResponse:
       allOf:
@@ -710,7 +736,7 @@ components:
           properties:
             data:
               $ref: '#/components/schemas/RefreshData'
-    
+
     RegisterSuccessResponse:
       allOf:
         - $ref: '#/components/schemas/ApiSuccessBase'
@@ -729,7 +755,7 @@ components:
           properties:
             data:
               $ref: '#/components/schemas/OtpSendSuccessData'
-    
+
     OtpVerifySuccessResponse:
       allOf:
         - $ref: '#/components/schemas/ApiSuccessBase'
@@ -762,7 +788,7 @@ components:
     # Set-Cookie は複数行返る可能性あり（本ヘッダは代表記述）
     AdminSessionCookie:
       description: |
-        Cookieのセット（admin_status=3(本登録)の場合）
+        Cookieのセット（ログイン成功時: 200/202 等。admin_status の値は状態により変化）
         ```
         ln_admin_sid={ln_admin_sid}; Path=/; HttpOnly; Secure; SameSite=<see note>; Max-Age=1800
         admin_status={admin_status}; Path=/; HttpOnly; Secure; SameSite=<see note>; Max-Age=1800
@@ -1079,5 +1105,3 @@ components:
                 details: {}
                 requestId: "req_conflict_409"
                 timestamp: "2025-10-27T10:45:12.901Z"
-
-


### PR DESCRIPTION
・改修内容に関して
data > admin > adminStatus の追加

・リファクタリング内容に関して
verifySessionOld関数を使用しない
代わりに

verifySession関数でセッションの有効性を検証
verifySessionの結果を受けて、getSession関数で返却するdataを構築する